### PR TITLE
fixed time error

### DIFF
--- a/src/gradient_cost_layer.cpp
+++ b/src/gradient_cost_layer.cpp
@@ -344,6 +344,8 @@ namespace gradient_cost_plugin
         cloud->header.frame_id.c_str(), ex.what());
       return;
     }
+
+    last_data_time_ = clock_->now();
   }
 
 
@@ -364,7 +366,7 @@ namespace gradient_cost_plugin
                                        double* min_x, double* min_y,
                                        double* max_x, double* max_y)
   {
-    std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());  
+    std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
 
     auto node = node_.lock();
 


### PR DESCRIPTION
I was getting the following error:

```
[component_container_isolated-1] terminate called after throwing an instance of 'std::runtime_error'
[component_container_isolated-1]   what():  can't subtract times with different time sources [1 != 2]
[ERROR] [component_container_isolated-1]: process has died [pid 23185, exit code -6, cmd '/opt/ros/humble/lib/rclcpp_components/component_container_isolated --ros-args --log-level info --ros-args -r __node:=nav2_container --params-file /tmp/launch_params_e8j2qjxe --params-file /tmp/launch_params_0h8cw5ss -r /tf:=tf -r /tf_static:=tf_static'].
```

This appears to have addressed the issue.